### PR TITLE
Improve org profile README: community-first tone, fix blog link, add UTM

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,24 +2,21 @@
 
 [ [Tools](https://github.com/search?q=topic%3Atools+org%3AEyevinn+fork%3Atrue) | [Testing Tools](https://github.com/search?q=topic%3Atesting-tools+org%3AEyevinn+fork%3Atrue) | [Libraries](https://github.com/search?q=topic%3Alibrary+org%3AEyevinn+fork%3Atrue) | [Services](https://github.com/search?q=topic%3Aservice+org%3AEyevinn+fork%3Atrue) | [Applications](https://github.com/search?q=topic%3Aapplication+org%3AEyevinn+fork%3Atrue) ] 
 
-## Welcome visitor 👋
+## Open source video streaming, built in public
 
 ![An illustration showing a piece of puzzle in a hand](https://d1okaosfjqp6sh.cloudfront.net/image/upload/v1528726315/Genre-Unsplash/ryoji-iwata-669950-unsplash-Edited.png)
 
-Glad you found our little spot on Internet!
+We are [Eyevinn Technology](https://www.eyevinn.se?utm_source=github&utm_medium=readme&utm_campaign=org), a video and streaming specialist firm based in Stockholm. We build and share open source tools for media engineers working with HLS, MPEG-DASH, WebRTC, SRT, FAST channels, player analytics, and related technologies.
 
-We are [Eyevinn Technology](https://www.eyevinntechnology.se), and we help companies in the TV, media, and entertainment sectors optimize costs and boost profitability through enhanced media solutions.
-We are independent in a way that we are not commercially tied to any platform or technology vendor. As our way to innovate and push the industry forward, we develop proof-of-concepts and tools. We share things we have learn and code as open-source.
-
-With Eyevinn Open Source Cloud we enable to build solutions and applications based on Open Web Services and avoid being locked in with a single web service vendor. Our open-source solutions offer full flexibility with a revenue share model that supports the creators.
+Everything here is free to use, fork, and self-host. If you want to skip the infrastructure management, most of our tools are also available as hosted services on [Open Source Cloud](https://www.osaas.io?utm_source=github&utm_medium=readme&utm_campaign=org). Zero lock-in, cancel anytime.
 
 Read our blogs and articles here:
 - [Developer blogs](https://dev.to/video)
 - [Medium](https://eyevinntechnology.medium.com)
-- [OSC](https://www.osaas.io)
+- [OSC blog](https://www.osaas.io/blog?utm_source=github&utm_medium=readme&utm_campaign=org)
 - [LinkedIn](https://www.linkedin.com/company/eyevinn/)
 
-Want to know more about Eyevinn, contact us at info@eyevinn.se!
+Questions? Open an issue in the relevant repo or reach out at info@eyevinn.se
 
 ## Slack
 


### PR DESCRIPTION
## Summary

- Rewrite opening paragraph from consultant-speak to developer/community-first framing
- Fix OSC blog link (was pointing to osaas.io homepage, now goes to osaas.io/blog)
- Add UTM tracking to all osaas.io and eyevinn.se links (`utm_source=github&utm_medium=readme&utm_campaign=org`)
- Update website reference from eyevinntechnology.se to eyevinn.se

## Framing principle

The message is: repos are 100% open source and free to self-host. OSC is mentioned as an optional convenience, not a requirement. This keeps the tone right for the open-source community.

## Test plan

- [ ] Review rendered README at github.com/Eyevinn after merge
- [ ] Confirm blog link resolves to osaas.io/blog
- [ ] Confirm UTM params appear in analytics when clicking through

Note: org description, website field, and pinned repos require owner-level access and are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)